### PR TITLE
Add get captain history endpoint endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Shell Tech Test
+
+## Endpoints
+
+### GET: /history/:captainName
+#### REQUEST
+`captainName` - a captains name in the format `<FirstName>+<Surname>` (case insensitive)
+#### RESPONSE 
+a captain's journey history in JSON format:
+```$json
+{
+    "captainName": "patsy stone",
+    "trips": [
+        {
+            "vessel": "El Tauro",
+            "from": "Singapore",
+            "to": "Melbourne",
+            "fromDate": 1514764800000,
+            "toDate": 1515888000000
+        }
+    ]
+}
+```

--- a/__tests_/example.spec.js
+++ b/__tests_/example.spec.js
@@ -1,8 +1,0 @@
-'use strict';
-
-
-describe('example', () => {
-    test('the fundamental truth', () => {
-        expect(true).toBe(true)
-    })
-});

--- a/__tests_/src/controllers/get-history.spec.js
+++ b/__tests_/src/controllers/get-history.spec.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const getHistory = require('../../../src/controllers/get-history');
+const fakeUpstream = require('../../../src/lib/fake-upstream');
+const res = {
+    sendStatus: jest.fn(),
+    send: jest.fn()
+};
+
+jest.mock('../../../src/lib/fake-upstream');
+
+describe('getHistory controller', () => {
+    afterEach(() => {
+       fakeUpstream.getCaptain.mockRestore();
+       res.sendStatus.mockRestore();
+       res.send.mockRestore();
+    });
+    test('it should return 404 if the captain doesnt exist', () => {
+        fakeUpstream.getCaptain.mockReturnValue(undefined);
+        getHistory({params: {captainName: 'Captain+Nobody'}}, res);
+        expect(fakeUpstream.getCaptain).toBeCalledWith('Captain Nobody');
+        expect(res.sendStatus).toBeCalledWith(404)
+    });
+    test('it should return the captain if the captain doesexist', () => {
+        fakeUpstream.getCaptain.mockReturnValue({captainName: 'Captain Somebody', trips: []});
+        getHistory({params: {captainName: 'Captain+Somebody'}}, res);
+        expect(fakeUpstream.getCaptain).toBeCalledWith('Captain Somebody');
+        expect(res.send).toBeCalledWith({captainName: 'Captain Somebody', trips: []})
+    });
+});

--- a/__tests_/src/lib/fake-upstream.spec.js
+++ b/__tests_/src/lib/fake-upstream.spec.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const {getCaptain} = require('../../../src/lib/fake-upstream');
+
+describe('get captain', () => {
+    test('it should return undefined if the captain does not exist', () => {
+        expect(getCaptain('Captain America')).toBeUndefined()
+    });
+    describe('when the captain exists', () => {
+        let result;
+        beforeAll(() => {
+            result = getCaptain('Patsy Stone')
+        });
+        test('it should return a captain object', () => {
+            expect(result).not.toBeUndefined();
+        });
+        test('the captain object should include the captains name', () => {
+            expect(result).toHaveProperty('captainName', 'Patsy Stone')
+        });
+        test('the captain object should include the journeys for that captain', () => {
+            expect(result).toHaveProperty('trips');
+            expect(result.trips).toEqual([
+                {
+                    vessel: 'El Tauro',
+                    from: 'Singapore',
+                    to: 'Melbourne',
+                    fromDate: 1514764800000,
+                    toDate: 1515888000000
+                }
+            ])
+        })
+    });
+});

--- a/__tests_/src/lib/fake-upstream.spec.js
+++ b/__tests_/src/lib/fake-upstream.spec.js
@@ -6,7 +6,7 @@ describe('get captain', () => {
     test('it should return undefined if the captain does not exist', () => {
         expect(getCaptain('Captain America')).toBeUndefined()
     });
-    describe('when the captain exists', () => {
+    describe('when the captain exists in the exact form provided', () => {
         let result;
         beforeAll(() => {
             result = getCaptain('Patsy Stone')
@@ -30,4 +30,10 @@ describe('get captain', () => {
             ])
         })
     });
+    test('it should fetch the captain in a case insensitive way', () => {
+        expect(getCaptain('patsy stone')).not.toBeUndefined();
+        expect(getCaptain('pAtsy stone')).not.toBeUndefined();
+        expect(getCaptain('patsy stOne')).not.toBeUndefined();
+        expect(getCaptain('patsY sTone')).not.toBeUndefined();
+    })
 });

--- a/index.js
+++ b/index.js
@@ -5,4 +5,6 @@ const express = require('express');
 const app = module.exports = express();
 const {PORT = 8080} = process.env;
 
+app.get('/history/:captainName', require('./src/controllers/get-history'));
+
 app.listen(PORT, () => console.log(`App listening on port: ${PORT}`));

--- a/src/controllers/get-history.js
+++ b/src/controllers/get-history.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const {getCaptain} = require('../lib/fake-upstream');
+
+module.exports = (req, res) => {
+    const {captainName} = req.params;
+    const formattedCaptainName = captainName.replace(new RegExp(/\+/, 'g'),' ');
+    const history = getCaptain(formattedCaptainName);
+    if (!history) {
+        return res.sendStatus(404);
+    }
+
+    return res.send(history);
+};

--- a/src/lib/fake-upstream.js
+++ b/src/lib/fake-upstream.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const CAPTAINS = ["Patsy Stone"];
+const JOURNEYS = [
+    {
+        captain: "Patsy Stone",
+        vessel: 'El Tauro',
+        from: 'Singapore',
+        to: 'Melbourne',
+        fromDate: 1514764800000,
+        toDate: 1515888000000
+    }
+];
+
+exports.getCaptain = (name) => {
+    if (CAPTAINS.includes(name)) {
+        return {
+            captainName: name,
+            trips: JOURNEYS
+                .filter(trip => trip.captain === name)
+                .map(({vessel, from, to, fromDate, toDate}) => ({vessel, from, to, fromDate, toDate}))
+        }
+    }
+};

--- a/src/lib/fake-upstream.js
+++ b/src/lib/fake-upstream.js
@@ -13,11 +13,12 @@ const JOURNEYS = [
 ];
 
 exports.getCaptain = (name) => {
-    if (CAPTAINS.includes(name)) {
+    if (!name) return;
+    if (CAPTAINS.find(captain => captain.toLowerCase() === name.toLowerCase())) {
         return {
             captainName: name,
             trips: JOURNEYS
-                .filter(trip => trip.captain === name)
+                .filter(trip => trip.captain.toLowerCase() === name.toLowerCase())
                 .map(({vessel, from, to, fromDate, toDate}) => ({vessel, from, to, fromDate, toDate}))
         }
     }


### PR DESCRIPTION
Adds the below endpoints

### GET: /history/:captainName
#### REQUEST
`captainName` - a captains name in the format `<FirstName>+<Surname>` (case insensitive)
#### RESPONSE 
a captain's journey history in JSON format:
```$json
{
    "captainName": "patsy stone",
    "trips": [
        {
            "vessel": "El Tauro",
            "from": "Singapore",
            "to": "Melbourne",
            "fromDate": 1514764800000,
            "toDate": 1515888000000
        }
    ]
}
```