### PR TITLE
Add api key auth middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,12 @@
 
 ## Endpoints
 
+All endpoints require an apiKey supplied via the `x-api-key` header.
+
 ### GET: /history/:captainName
 #### REQUEST
-`captainName` - a captains name in the format `<FirstName>+<Surname>` (case insensitive)
+`:captainName` - a captains name in the format `<FirstName>+<Surname>` (case insensitive)
+
 #### RESPONSE 
 a captain's journey history in JSON format:
 ```$json

--- a/__tests_/src/middleware/api-key.spec.js
+++ b/__tests_/src/middleware/api-key.spec.js
@@ -1,0 +1,53 @@
+'use strict';
+
+let middleware;
+const res = {
+    sendStatus: jest.fn()
+};
+const next = jest.fn();
+const clearMocks = () => {
+    res.sendStatus.mockRestore();
+    next.mockRestore();
+};
+
+describe('apiKeyMiddleWare', () => {
+   describe('when no api key is set', () => {
+       beforeAll(() => {
+           delete process.env.API_KEY;
+           jest.isolateModules(() => {
+               middleware = require('../../../src/middleware/api-key');
+           });
+           middleware({get: () => 'VALID KEY'}, res, next)
+       });
+       afterAll(clearMocks);
+       test('it should respond unauthorized', () => {
+           expect(res.sendStatus).toBeCalledWith(401);
+       })
+   });
+    describe('when api key is set but the supplied api key is invalid', () => {
+        beforeAll(() => {
+            process.env.API_KEY = 'VALID KEY';
+            jest.isolateModules(() => {
+                middleware = require('../../../src/middleware/api-key');
+            });
+            middleware({get: () => 'INVALID KEY'}, res, next)
+        });
+        afterAll(clearMocks);
+        test('it should respond unauthorized', () => {
+            expect(res.sendStatus).toBeCalledWith(401);
+        })
+    });
+    describe('when api key is set and the supplied api key is valid', () => {
+        beforeAll(() => {
+            process.env.API_KEY = 'VALID KEY';
+            jest.isolateModules(() => {
+                middleware = require('../../../src/middleware/api-key');
+            });
+            middleware({get: () => 'VALID KEY'}, res, next)
+        });
+        afterAll(clearMocks);
+        test('it should call next', () => {
+            expect(next).toBeCalled();
+        })
+    })
+});

--- a/src/middleware/api-key.js
+++ b/src/middleware/api-key.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const {API_KEY} = process.env;
+
+module.exports = (req, res, next) => {
+    if (API_KEY && req.get('x-api-key') === API_KEY) {
+        next();
+    } else {
+        res.sendStatus(401);
+    }
+};


### PR DESCRIPTION
Add middleware requiring an api-key supplied via the `x-api-key` header