### PR TITLE
Add post arrival endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,17 @@ a captain's journey history in JSON format:
     ]
 }
 ```
+
+### POST: /arrival
+#### REQUEST BODY
+```$json
+{
+	"captain": "Patsy+Stone",
+    "vessel": "El Tauro",
+    "datetime": "5th of Feb 2056",
+    "port": "Singapore"
+}
+```
+
+#### RESPONSE 
+201 - if successful

--- a/__tests_/src/controllers/post-arrival.spec.js
+++ b/__tests_/src/controllers/post-arrival.spec.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const postArrival = require('../../../src/controllers/post-arrival');
+const fakeUpstream = require('../../../src/lib/fake-upstream');
+const next = jest.fn();
+const res = {
+    sendStatus: jest.fn()
+};
+
+jest.mock('../../../src/lib/fake-upstream');
+
+const MOCK_BODY = {
+    captain: 'Patsy+Stone',
+    vessel: 'El Tauro',
+    datetime: '5th of Feb 2056',
+    port: 'Singapore'
+};
+
+describe('getHistory controller', () => {
+    afterEach(() => {
+       fakeUpstream.addArrival.mockRestore();
+       res.sendStatus.mockRestore();
+    });
+    test.each([
+        'Bad date format',
+        'Date too early',
+        'Missing Properties'
+    ])('it should return 400 if the upstream function throws a \'%s\' error', (errorMessage) => {
+        fakeUpstream.addArrival.mockImplementation(() => {
+            throw new Error(errorMessage);
+        });
+        postArrival({body: MOCK_BODY}, res, next);
+        expect(fakeUpstream.addArrival).toBeCalledWith({...MOCK_BODY, captain: 'Patsy Stone'});
+        expect(res.sendStatus).toBeCalledWith(400)
+    });
+
+    test.each([
+        'Captain not Found',
+        'Vessel not Found'
+    ])('it should return 400 if the upstream function throws a \'%s\' error', (errorMessage) => {
+        fakeUpstream.addArrival.mockImplementation(() => {
+            throw new Error(errorMessage);
+        });
+        postArrival({body: MOCK_BODY}, res, next);
+        expect(fakeUpstream.addArrival).toBeCalledWith({...MOCK_BODY, captain: 'Patsy Stone'});
+        expect(res.sendStatus).toBeCalledWith(404)
+    });
+
+    test('it should pass the errornext if the upstream function throws an unknown error', () => {
+        fakeUpstream.addArrival.mockImplementation(() => {
+            throw new Error('You sunk my battleship');
+        });
+        postArrival({body: MOCK_BODY}, res, next);
+        expect(fakeUpstream.addArrival).toBeCalledWith({...MOCK_BODY, captain: 'Patsy Stone'});
+        expect(next).toBeCalledWith(new Error('You sunk my battleship'))
+    });
+
+    test('it should return 201 if the upstream function returns succesfully', () => {
+        fakeUpstream.addArrival.mockReturnValue(true);
+        postArrival({body: MOCK_BODY}, res, next);
+        expect(fakeUpstream.addArrival).toBeCalledWith({...MOCK_BODY, captain: 'Patsy Stone'});
+        expect(res.sendStatus).toBeCalledWith(201)
+    });
+});

--- a/__tests_/src/lib/fake-upstream.spec.js
+++ b/__tests_/src/lib/fake-upstream.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const {getCaptain} = require('../../../src/lib/fake-upstream');
+const {getCaptain, addArrival, JOURNEYS} = require('../../../src/lib/fake-upstream');
 
 describe('get captain', () => {
     test('it should return undefined if the captain does not exist', () => {
@@ -36,4 +36,99 @@ describe('get captain', () => {
         expect(getCaptain('patsy stOne')).not.toBeUndefined();
         expect(getCaptain('patsY sTone')).not.toBeUndefined();
     })
+});
+
+describe('add arrival', () => {
+    test('it should throw an error if the captain does not exist', () => {
+        let err;
+        try {
+            addArrival({
+                captain: 'Captain America',
+                vessel: 'El Tauro',
+                datetime: '5th of Feb 2056',
+                port: 'Singapore'})
+        } catch(e) {
+            err = e
+        }
+        expect(err).toHaveProperty('message', 'Captain not Found')
+    });
+    test('it should throw if the journey is missing properties', () => {
+        let err;
+        try {
+            addArrival({
+                captain: 'Patsy Stone',
+                vessel: 'El Tauro',
+                datetime: '5th of Feb 2056'
+            })
+        } catch(e) {
+            err = e
+        }
+        expect(err).toHaveProperty('message', 'Missing Properties')
+    });
+    test('it should throw if the vessel has no previous history', () => {
+        let err;
+        try {
+            addArrival({
+                captain: 'Patsy Stone',
+                vessel: 'SS Penguin',
+                datetime: '5th of Feb 2056',
+                port: 'Singapore'
+            })
+        } catch(e) {
+            err = e
+        }
+        expect(err).toHaveProperty('message', 'Vessel not Found')
+    });
+    test('it should throw if the datetime is not in the expected format', () => {
+        let err;
+        try {
+            addArrival({
+                captain: 'Patsy Stone',
+                vessel: 'El Tauro',
+                datetime: '2056/02/05',
+                port: 'Singapore'
+            })
+        } catch(e) {
+            err = e
+        }
+        expect(err).toHaveProperty('message', 'Bad date format')
+    });
+    test('it should throw if the datetime is before the last reported date for the vessel', () => {
+        let err;
+        try {
+            addArrival({
+                captain: 'Patsy Stone',
+                vessel: 'El Tauro',
+                datetime: '5th of Feb 2000',
+                port: 'Singapore'
+            })
+        } catch(e) {
+            err = e
+        }
+        expect(err).toHaveProperty('message', 'Date too early')
+    });
+    describe('when the captain exists and the journey is correctly formatted', () => {
+        let result;
+        beforeAll(() => {
+            result = addArrival({
+                captain: 'Patsy Stone',
+                vessel: 'El Tauro',
+                datetime: '5th of Feb 2056',
+                port: 'Singapore'
+            })
+        });
+        test('it should return true', () => {
+            expect(result).toEqual(true)
+        });
+        test('it adds a journey to the journey\'s array with the fromDate being the vessel\'s last arrival in a port', () => {
+            expect(JOURNEYS).toContainEqual({
+                captain: 'Patsy Stone',
+                vessel: 'El Tauro',
+                from: 'Melbourne',
+                to: 'Singapore',
+                fromDate: 1515888000000,
+                toDate: 2716934400000
+            })
+        })
+    });
 });

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const express = require('express');
 const app = module.exports = express();
 const {PORT = 8080} = process.env;
 
+app.use(require('body-parser').json());
 app.get('/history/:captainName', require('./src/controllers/get-history'));
-
+app.post('/arrival', require('./src/controllers/post-arrival'));
 app.listen(PORT, () => console.log(`App listening on port: ${PORT}`));

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "jest": "^24.9.0"
   },
   "dependencies": {
+    "body-parser": "^1.19.0",
     "express": "^4.17.1",
     "moment": "^2.24.0"
   }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "jest": "^24.9.0"
   },
   "dependencies": {
-    "express": "^4.17.1"
+    "express": "^4.17.1",
+    "moment": "^2.24.0"
   }
 }

--- a/src/controllers/post-arrival.js
+++ b/src/controllers/post-arrival.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const {addArrival} = require('../lib/fake-upstream');
+
+module.exports = (req, res, next) => {
+    const {captain, port, vessel, datetime} = req.body;
+     try {
+         addArrival({captain: captain.replace(new RegExp(/\+/, 'g'), ' '), port, vessel, datetime});
+     } catch(err) {
+         if (err.message.toLowerCase().endsWith('not found')) return res.sendStatus(404);
+         if (['Bad date format', 'Date too early', 'Missing Properties'].includes(err.message)) {
+             return res.sendStatus(400);
+         }
+         return next(err)
+     }
+
+    return res.sendStatus(201);
+};

--- a/src/lib/fake-upstream.js
+++ b/src/lib/fake-upstream.js
@@ -1,7 +1,9 @@
 'use strict';
 
+const moment = require('moment');
+
 const CAPTAINS = ["Patsy Stone"];
-const JOURNEYS = [
+const JOURNEYS = exports.JOURNEYS = [
     {
         captain: "Patsy Stone",
         vessel: 'El Tauro',
@@ -22,4 +24,32 @@ exports.getCaptain = (name) => {
                 .map(({vessel, from, to, fromDate, toDate}) => ({vessel, from, to, fromDate, toDate}))
         }
     }
+};
+
+exports.addArrival = ({captain: captainName, vessel, datetime, port} = {}) => {
+    if (!CAPTAINS.find(captain => captain.toLowerCase() === captainName.toLowerCase())) throw new Error('Captain not Found');
+    if ([vessel, datetime, port].includes(undefined)) throw new Error('Missing Properties');
+
+    // Parse Datetime
+    const parsedDateTime = moment(datetime, 'Do [of] MMM YYYY');
+    if (parsedDateTime.format('Do [of] MMM YYYY') !== datetime) throw new Error('Bad date format');
+
+    // Get Previous Journey for Vessel
+    const js = JOURNEYS.filter((j) => vessel === j.vessel).sort((a, b) => b.toDate - a.toDate);
+    const [previousJourney] = js;
+    if (!previousJourney) throw new Error('Vessel not Found');
+    if (previousJourney.toDate >= parsedDateTime.unix() * 1000) throw new Error('Date too early');
+
+
+    const journey = {
+        captain: CAPTAINS.find(captain => captain.toLowerCase() === captainName.toLowerCase()),
+        vessel,
+        from: previousJourney.to,
+        to: port,
+        fromDate: previousJourney.toDate,
+        toDate: moment(datetime, 'Do [of] MMM YYYY').unix() * 1000
+    };
+
+    JOURNEYS.push(journey);
+    return true
 };


### PR DESCRIPTION
Adds the following endpoints

### POST: /arrival
#### REQUEST BODY
```$json
{
	"captain": "Patsy+Stone",
    "vessel": "El Tauro",
    "datetime": "5th of Feb 2056",
    "port": "Singapore"
}
```

#### RESPONSE 
201 - if successful